### PR TITLE
Add the ability to use Google Analytics to track page views and events

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@
 
         /**
          * @func _trackAnalyticsEvent
-         * @param {String} eventCategory
-         * @param {String} eventAction
-         * @param {String} eventLabel
-         * @param {String} eventValue
+         * @param {String} eventCategory Max length of 150 bytes
+         * @param {String} eventAction Max length of 500 bytes
+         * @param {String} eventLabel Max length of 500 bytes
+         * @param {Integer} eventValue No max length
          * @desc Track an event using Google Analytics' event tracking API
          * @see https://developers.google.com/analytics/devguides/collection/analyticsjs/events
          */
@@ -54,16 +54,11 @@
                     eventValue = "";
                 }
 
-                console.log('Sending event to Google Analytics with eventCategory = "' + eventCategory + '", eventAction' +
-                    ' = "' + eventAction + '", eventLabel = "' + eventLabel + '", eventValue = "' + eventValue + '"');
                 ga('send', 'event', eventCategory, eventAction, eventLabel, eventValue);
-            } else {
-                console.log('Tracking of events via analytics is disabled');
             }
         },
 
         _trackAnalyticsPage: function () {
-            console.log('Sending page view to Google Analytics');
             ga('send', 'pageview');
         }
     };

--- a/index.js
+++ b/index.js
@@ -1158,6 +1158,7 @@
                 onEachFeature: function (feature, layer) {
                     if(geoJsonCollection._click !== false) {
                         layer.on('click', function () {
+                            self._trackAnalyticsEvent('mapView', 'layerClick-' + layerId, 'Clicked on icon or multilinestring', feature.properties.id);
                             if(!self._isPopupRoute(Backbone.history.fragment.split("/"))) {
                                 NZTAComponents.router._previousFragment = Backbone.history.fragment;
                             }

--- a/index.js
+++ b/index.js
@@ -869,6 +869,8 @@
         initialize: function (options) {
 
             this.model = (options !== void 0 && options.model !== void 0) ? options.model : new NZTAComponents.MapModel();
+            this.trackAnalyticsEvents = (options !== void 0 && options.trackAnalyticsEvents !== void 0) ? options.trackAnalyticsEvents : false;
+
             this.model.set('vent', this.options.vent);
 
             this.mapLayers = [];
@@ -917,6 +919,17 @@
             this.listenTo(this.model, 'data.all', function (features) {
                 this.options.vent.trigger('map.update.all', features);
             }, this);
+
+            // Log analytics event whenever any zoom ends (e.g. when the zoomIn button is clicked, if a cluster or icon
+            // is clicked on and the map zooms in, and if the user manually zooms in using for example the scroll wheel
+            var mapViewComponent = this;
+            this.map.on('zoomend', function() {
+                mapViewComponent._trackAnalyticsEvent('mapView', 'mapZoomLevelChanged', 'Recorded anytime zoom level changes, irrespective of direction (in or out) or source (scroll, click, button click)');
+            });
+
+            this.map.on('dragend', function() {
+                mapViewComponent._trackAnalyticsEvent('mapView', 'mapDragged', 'Recorded anytime the map is dragged/panned around by visitors');
+            });
         },
 
         /**

--- a/index.js
+++ b/index.js
@@ -46,15 +46,20 @@
          */
         _trackAnalyticsEvent: function (eventCategory, eventAction, eventLabel, eventValue) {
             if (this.trackAnalyticsEvents) {
-                if (eventLabel === void 0) {
-                    eventLabel = "";
+                var eventData = {
+                    'eventCategory': eventCategory,
+                    'eventAction': eventAction
+                };
+
+                if (eventLabel !== void 0) {
+                    eventData['eventLabel'] = eventLabel;
                 }
 
-                if (eventValue === void 0) {
-                    eventValue = "";
+                if (eventValue !== void 0 && !isNaN(parseInt(eventValue))) {
+                    eventData['eventValue'] = parseInt(eventValue);
                 }
 
-                ga('send', 'event', eventCategory, eventAction, eventLabel, eventValue);
+                ga('send', 'event', eventData);
             }
         },
 
@@ -1162,7 +1167,7 @@
                     if(geoJsonCollection._click !== false) {
                         layer.on('click', function () {
                             var location = ((feature !== void 0 && feature.properties !== void 0 && feature.properties.regions !== void 0 && feature.properties.regions[0] !== void 0) ? feature.properties.regions[0].name : '');
-                            self._trackAnalyticsEvent('mapView', 'layerClick-' + location + '-' + layerId, 'Clicked on pin or multilinestring', feature.properties.id);
+                            self._trackAnalyticsEvent('mapView', 'layerClick-' + location + '-' + layerId, feature.properties.id);
                             if(!self._isPopupRoute(Backbone.history.fragment.split("/"))) {
                                 NZTAComponents.router._previousFragment = Backbone.history.fragment;
                             }
@@ -1408,7 +1413,7 @@
          */
         _zoomIn: function () {
             this.options.vent.trigger('userControls.zoomIn');
-            this._trackAnalyticsEvent('userControls', 'zoomIn', 'Right sidebar buttons');
+            this._trackAnalyticsEvent('userControls', 'zoomIn');
         },
 
         /**
@@ -1417,7 +1422,7 @@
          */
         _zoomOut: function () {
             this.options.vent.trigger('userControls.zoomOut');
-            this._trackAnalyticsEvent('userControls', 'zoomOut', 'Right sidebar buttons');
+            this._trackAnalyticsEvent('userControls', 'zoomOut');
         },
 
         /**
@@ -1427,7 +1432,7 @@
          */
         _locateUser: function () {
             this.options.vent.trigger('userControls.locateUser', this.options.locateUserMaxZoom);
-            this._trackAnalyticsEvent('userControls', 'locateUser', 'Right sidebar buttons');
+            this._trackAnalyticsEvent('userControls', 'locateUser');
         },
 
         /**
@@ -1441,7 +1446,7 @@
 
             $('body').toggleClass('tools-active');
 
-            this._trackAnalyticsEvent('userControls', 'toggleMapLayerToolbox', 'Right sidebar buttons', (mapFiltersOpen === true ? 'opening' : 'closing'));
+            this._trackAnalyticsEvent('userControls', 'toggleMapLayerToolbox', (mapFiltersOpen === true ? 'opened' : 'closed'));
         },
 
         /**
@@ -1450,10 +1455,12 @@
          * @desc Trigger an events which toggles a map layer.
          */
         _toggleMapLayer: function (e) {
-            var selectedLayer = Backbone.$(e.currentTarget).data('layer');
+            var selectedLayer = Backbone.$(e.currentTarget).data('layer'),
+                checked = $(e.currentTarget).is(':checked');
+
             this.options.vent.trigger('userControls.toggleMapLayer', selectedLayer);
 
-            this._trackAnalyticsEvent('userControls', 'toggleMapLayer', 'Right sidebar buttons', selectedLayer);
+            this._trackAnalyticsEvent('userControls', 'toggleMapLayer-' + selectedLayer, (checked ? 'show' : 'hide'));
         },
 
         /**


### PR DESCRIPTION
Page views are triggered whenever the `_handleNav` action is called on the `Router`.

Events are triggered for certain user actions that don't affect the router, for example zooming in and out of the map, panning the map etc.
