### PR TITLE
Use new regenerated Slack integration token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ node_js:
   - "0.10"
 script: "npm run test"
 notifications:
-  slack: silverstripeltd:MKoWwPwo6IUECYClkElwFOoM
+  slack:
+    rooms:
+      secure: R8qg+jT647UKhP7HXxNljy6UV5Z3jh2qPc1ux0gT5gA6qKnbg65PEpH/K5i3N23MQsTjWWnO6owhQM//uF+Mm6FeapvMqGYIJYPROfxrYoamKIBu9xHtQem+zmv2ygHHCjhyKGNBSswQ9VmAqysAO0GWYmnapIY/o49OJYiNa1k=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NZTA Map Components
 
-[![Build Status](https://travis-ci.org/silverstripe-iterators/nzta-map-components.svg)](https://travis-ci.org/silverstripe-iterators/nzta-map-components)
+[![Build Status](https://travis-ci.org/NZTA/nzta-map-components.svg)](https://travis-ci.org/NZTA/nzta-map-components)
 
 A collection of Backbone components useful for building NZTA maps.
 


### PR DESCRIPTION
The previous token has been revoked, this config contains a new, encrypted token which is safe
for open source.